### PR TITLE
Introduce Symbols type

### DIFF
--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/javadefref/JavaSourceEntityExtractor.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/javadefref/JavaSourceEntityExtractor.scala
@@ -39,7 +39,7 @@ object JavaSourceEntityExtractor {
      }).map(structureOf(_))
   }
 
-  private def structureOf(compUnit: CompilationUnit): DataBlock = {
+  private def structureOf(compUnit: CompilationUnit): Symbols = {
     import Entity._
     // The parser is imperative and mutable, so we take a non-idiomatic
     // approach here and use mutable values to keep state

--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/javadefref/Main.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/javadefref/Main.scala
@@ -1,12 +1,10 @@
 package io.bazeltools.buildgen.javadefref
 
-import cats.effect.{IO}
-import io.bazeltools.buildgen.shared.DataBlock
-import io.bazeltools.buildgen.shared.DriverApplication
+import cats.effect.IO
+import io.bazeltools.buildgen.shared.{Symbols, DriverApplication}
 
 object Main extends DriverApplication {
   def name: String = "java_extractor"
-  def extract(data: String): IO[DataBlock] = {
+  def extract(data: String): IO[Symbols] =
     JavaSourceEntityExtractor.extract(data)
-  }
 }

--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/scaladefref/Main.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/scaladefref/Main.scala
@@ -1,12 +1,10 @@
 package io.bazeltools.buildgen.scaladefref
 
 import cats.effect.{IO}
-import io.bazeltools.buildgen.shared.DataBlock
-import io.bazeltools.buildgen.shared.DriverApplication
+import io.bazeltools.buildgen.shared.{Symbols, DriverApplication}
 
 object Main extends DriverApplication {
   def name: String = "scala_extractor"
-  def extract(data: String): IO[DataBlock] = {
+  def extract(data: String): IO[Symbols] =
     ScalaSourceEntityExtractor.extract(data)
-  }
 }

--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/shared/DataApi.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/shared/DataApi.scala
@@ -15,12 +15,14 @@ object ExtractedData {
     deriveEncoder[ExtractedData]
 }
 
-final case class DataBlock(
-    entity_path: String,
+final case class Symbols(
     defs: SortedSet[Entity],
     refs: SortedSet[Entity],
-    bzl_gen_build_commands: SortedSet[String] = SortedSet.empty
+    bzl_gen_build_commands: SortedSet[String]
 ) {
+  def withEntityPath(epath: String): DataBlock =
+    DataBlock(epath, defs, refs, bzl_gen_build_commands)
+
   def addDef(e: Entity) = copy(defs = defs + e)
   def addRef(e: Entity) = copy(refs = refs + e)
   def addBzlBuildGenCommand(e: String) =
@@ -29,20 +31,29 @@ final case class DataBlock(
     copy(bzl_gen_build_commands = bzl_gen_build_commands ++ e)
 }
 
-object DataBlock {
-  implicit val dataBlockEncoder: Encoder[DataBlock] = deriveEncoder[DataBlock]
+object Symbols {
+  val empty: Symbols =
+    Symbols(SortedSet.empty, SortedSet.empty, SortedSet.empty)
 
-  val empty: DataBlock = DataBlock("", SortedSet.empty, SortedSet.empty)
-
-  implicit val DataBlockMonoid: Monoid[DataBlock] =
-    new Monoid[DataBlock] {
-      def empty = DataBlock.empty
-      def combine(left: DataBlock, right: DataBlock) =
-        DataBlock(
-          entity_path = left.entity_path,
+  implicit val SymbolsMonoid: Monoid[Symbols] =
+    new Monoid[Symbols] {
+      def empty = Symbols.empty
+      def combine(left: Symbols, right: Symbols) =
+        Symbols(
           left.defs | right.defs,
           left.refs | right.refs,
           left.bzl_gen_build_commands | right.bzl_gen_build_commands
         )
     }
+}
+
+final case class DataBlock(
+    entity_path: String,
+    defs: SortedSet[Entity],
+    refs: SortedSet[Entity],
+    bzl_gen_build_commands: SortedSet[String]
+)
+
+object DataBlock {
+  implicit val dataBlockEncoder: Encoder[DataBlock] = deriveEncoder[DataBlock]
 }

--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/shared/DriverApplication.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/shared/DriverApplication.scala
@@ -13,7 +13,7 @@ import io.circe.syntax.EncoderOps
 
 abstract class DriverApplication extends IOApp {
   def name: String
-  def extract(data: String): IO[DataBlock]
+  def extract(data: String): IO[Symbols]
 
   def readToString(path: Path): IO[String] =
     IO.blocking(
@@ -45,7 +45,7 @@ abstract class DriverApplication extends IOApp {
               )
             )
         }
-      } yield e.copy(entity_path = path)
+      } yield e.withEntityPath(path)
     }
   }
   def main: Command[IO[ExitCode]] = decline.Command(

--- a/language_generators/scala-defref-extractor/src/test/scala/io/bazeltools/buildgen/javadefref/CanParseFileTest.scala
+++ b/language_generators/scala-defref-extractor/src/test/scala/io/bazeltools/buildgen/javadefref/CanParseFileTest.scala
@@ -7,7 +7,7 @@ import cats.effect.unsafe.implicits.global
 
 class CanParseFileTest extends AnyFunSuite {
 
-  def assertParse(str: String, expected: DataBlock) =
+  def assertParse(str: String, expected: Symbols) =
     assert(JavaSourceEntityExtractor.extract(str).unsafeRunSync() === expected)
 
   test("can extract a simple file") {
@@ -18,13 +18,12 @@ class CanParseFileTest extends AnyFunSuite {
 
     }
     """
-    val expectedDataBlock = DataBlock(
-      "",
+    val expectedSymbols = Symbols(
       defs = SortedSet(Entity.dotted("com.foo.bar.Cat")),
       refs = SortedSet(),
-      bzl_gen_build_commands = SortedSet()
+      bzl_gen_build_commands = SortedSet.empty
     )
-    assertParse(simpleContent, expectedDataBlock)
+    assertParse(simpleContent, expectedSymbols)
   }
 
   test("can extract a was failing file") {
@@ -53,8 +52,7 @@ public interface ExampleIntegerEncoder {
     }
 }
     """
-    val expectedDataBlock = DataBlock(
-      "",
+    val expectedSymbols = Symbols(
       defs = SortedSet(Entity.dotted("com.foo.bar.ExampleIntegerEncoder")),
       refs = SortedSet(
         Entity.dotted("Animal"),
@@ -86,7 +84,7 @@ public interface ExampleIntegerEncoder {
       ),
       bzl_gen_build_commands = SortedSet()
     )
-    assertParse(simpleContent, expectedDataBlock)
+    assertParse(simpleContent, expectedSymbols)
   }
 
 }

--- a/language_generators/scala-defref-extractor/src/test/scala/io/bazeltools/buildgen/javadefref/JavaSourceEntityExtractorTest.scala
+++ b/language_generators/scala-defref-extractor/src/test/scala/io/bazeltools/buildgen/javadefref/JavaSourceEntityExtractorTest.scala
@@ -1,6 +1,6 @@
 package io.bazeltools.buildgen.javadefref
 
-import io.bazeltools.buildgen.shared.{DataBlock, Entity}
+import io.bazeltools.buildgen.shared.{Symbols, Entity}
 import scala.collection.immutable.SortedSet
 
 import cats.effect.IO
@@ -10,7 +10,7 @@ class JavaSourceEntityExtractorTest extends munit.CatsEffectSuite {
 
   case class DefsRefs(defs: SortedSet[Entity], refs: SortedSet[Entity])
 
-  def extractString(in: String): IO[DataBlock] =
+  def extractString(in: String): IO[Symbols] =
     JavaSourceEntityExtractor.extract(in)
 
   def ents(s: String): SortedSet[Entity] =
@@ -59,8 +59,7 @@ class JavaSourceEntityExtractorTest extends munit.CatsEffectSuite {
     class Bar { }
     """)
 
-    val expected = DataBlock(
-      "",
+    val expected = Symbols(
       defs = ents("""["foo.bar.Bar"]"""),
       refs = ents("""["some.Pack"]"""),
       bzl_gen_build_commands = SortedSet("ref:fizzy", "unref:some.Pack")


### PR DESCRIPTION
previously we were returning `DataBlock` which has a `entity_path` which the jvm extractors could not know since they are only passed the content. To get around this, we just set it to the empty string, but it is a bit confusing to carry an extra field that is always unused.

This adds a `Symbols` type which just returns the values we can set, then you can create a `DataBlock` by adding the `entity_path` which the driver application knows.