### PR TITLE
Inline lazy log in scala extractor

### DIFF
--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/scaladefref/ScalaSourceEntityExtractor.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/scaladefref/ScalaSourceEntityExtractor.scala
@@ -256,9 +256,9 @@ object ScalaSourceEntityExtractor {
       case Left(_)    => Monad[Env].unit
     }
 
-  def log(s: String): Unit = {
-    require(s ne null)
-  }
+  // the idea here is we can replace the body with an actual log output if we are debugging
+  @inline
+  final def log(s: => String): Unit = ()
 
   def typeSelectToName(outerTerm: Term.Ref, n: Name): NonEmptyList[Name] = {
     @annotation.tailrec


### PR DESCRIPTION
we generally don't use the log function but have it there for debugging. The problem is the log strings may be fairly expensive to build since it requires rendering the code (and we do it at each level, so it can be much larger than the original file).

This change makes log call by name (so it is an allocation of a thunk, but we don't actually have to create the string), but also in the normal case we do nothing (return unit) and label it as inline so hopefully even that allocation can be removed by either scala or the JVM.

This may make a measurable difference in scala symbol extraction speed. 