### PR TITLE
Try to fix issue #8

### DIFF
--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/javadefref/JavaSourceEntityExtractor.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/javadefref/JavaSourceEntityExtractor.scala
@@ -21,6 +21,7 @@ import com.github.javaparser.ParseProblemException
  * https://github.com/pantsbuild/pants/blob/4e7c57db992150b3fc972e684561edb8231bba3d/src/python/pants/backend/java/dependency_inference/PantsJavaParserLauncher.java#L1
  */
 object JavaSourceEntityExtractor {
+  // this is mutable, so we need to guard any access
   private[this] lazy val parser = {
     val config = new ParserConfiguration();
 
@@ -30,15 +31,16 @@ object JavaSourceEntityExtractor {
   }
 
   def extract(content: String): IO[DataBlock] = {
-    val result = parser.parse(content)
-    (if (result.isSuccessful()) {
-       IO.pure(result.getResult().get())
-     } else {
-       IO.raiseError(new ParseProblemException(result.getProblems()))
-     }).map(structureOf(_))
+    val result = parser.synchronized { parser.parse(content) }
+    if (result.isSuccessful()) {
+      val cu = result.getResult().get()
+      IO.pure(structureOf(cu))
+    } else {
+      IO.raiseError(new ParseProblemException(result.getProblems()))
+    }
   }
 
-  def structureOf(compUnit: CompilationUnit): DataBlock = {
+  private def structureOf(compUnit: CompilationUnit): DataBlock = {
     import Entity._
     // The parser is imperative and mutable, so we take a non-idiomatic
     // approach here and use mutable values to keep state


### PR DESCRIPTION
try to fix #8 

I can't seem to repeat that flake, but I did find that the JavaParser type is mutable:

https://github.com/javaparser/javaparser/blob/54d7064d806a0fb2aec2c4f2d70a8a0f8bdfdb90/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java#L89

note that method changes the astParser field and then accesses it multiple times. It could have been safer by making a new item, updating that item, doing a single write to the field, but returning the newly created item.

Anyway... using a mutex on the parser should fix the issue and I expect have no measurable performance impact. We could also just allocate a new parser on each parse, or we could do an atomic swap with null and if we get the null value, allocate in only that case. Lots of options...